### PR TITLE
Add the missing comment sign # on line 59, nginx conf location on Ubuntu

### DIFF
--- a/intl.en-US/User Guide/Download and install SSL certificates/Install SSL certificates in Nginx__Tengine servers.md
+++ b/intl.en-US/User Guide/Download and install SSL certificates/Install SSL certificates in Nginx__Tengine servers.md
@@ -50,12 +50,13 @@ In this example, the certificate name is **domain name**, the certificate file i
       location / {
     						
     ```
-
+    Note that on Ubuntu, you may not find the above attributes in nginx.conf, instead, they are located in /etc/nginx/sites-enabled/default.
+    
     Modify the nginx.conf file as follows:
 
     ``` {#codeblock_xt8_f4t_yvg}
     
-    The attributes that start with "ssl" are related to certificate configurations, while the others can be configured as needed.
+    # The attributes that start with "ssl" are related to certificate configurations, while the others can be configured as needed.
     server {
     listen 443;
     server_name localhost;  # Replace localhost with the domain name bound to your certificate.


### PR DESCRIPTION
As titled.
One more thing for line 69 - ssl_ciphers value is not compatible with latest nginx version, i have to remove it to make the cert work, please advice the correct value now.